### PR TITLE
Cache clearance and warning off

### DIFF
--- a/brian2_benchmark/complicated_small.py
+++ b/brian2_benchmark/complicated_small.py
@@ -22,6 +22,7 @@ from brian2 import (
     SpikeMonitor,
     Synapses,
     codegen,
+    device,
 )
 
 codegen.target = "cython"
@@ -79,7 +80,13 @@ beta_n = .5*exp((10*mV-v+VT)/(40*mV))/ms : Hz
 """
 )
 defaultclock.dt = 0.05 * ms
-P = NeuronGroup(400, model=eqs, threshold="v>25*mV", method="rk4")
+P = NeuronGroup(
+    400, 
+    model=eqs, 
+    threshold="v>25*mV",
+    refractory='v>-25*mV',
+    method="rk4"
+)
 
 Ci = Synapses(
     P,
@@ -116,3 +123,5 @@ endsimulate = time.time()
 print(f"Building time     : {(endbuild - startbuild):0.2f} s")
 print(f"Simulation time   : {(endsimulate - endbuild):0.2f} s")
 print(f"Time step         : {(defaultclock.dt * 1000.0):0.2f} ms")
+
+device.delete(force=True)

--- a/brian2_benchmark/complicated_small.py
+++ b/brian2_benchmark/complicated_small.py
@@ -81,11 +81,7 @@ beta_n = .5*exp((10*mV-v+VT)/(40*mV))/ms : Hz
 )
 defaultclock.dt = 0.05 * ms
 P = NeuronGroup(
-    400, 
-    model=eqs, 
-    threshold="v>25*mV",
-    refractory='v>-25*mV',
-    method="rk4"
+    400, model=eqs, threshold="v>25*mV", refractory="v>-25*mV", method="rk4"
 )
 
 Ci = Synapses(

--- a/brian2_benchmark/complicated_small_omp.py
+++ b/brian2_benchmark/complicated_small_omp.py
@@ -24,9 +24,10 @@ from brian2 import (
     NeuronGroup,
     SpikeMonitor,
     Synapses,
+    device,
 )
 
-set_device("cpp_standalone", directory="ComplicatedSmall")
+set_device("cpp_standalone", directory=sys.argv[0][:-3])
 prefs.devices.cpp_standalone.openmp_threads = os.cpu_count()
 
 startbuild = time.time()
@@ -82,7 +83,13 @@ beta_n = .5*exp((10*mV-v+VT)/(40*mV))/ms : Hz
 """
 )
 defaultclock.dt = 0.05 * ms
-P = NeuronGroup(400, model=eqs, threshold="v>25*mV", method="rk4")
+P = NeuronGroup(
+    400,
+    model=eqs,
+    threshold="v>25*mV",
+    refractory='v>-25*mV',
+    method="rk4"
+)
 
 Ci = Synapses(
     P,
@@ -119,3 +126,5 @@ endsimulate = time.time()
 print(f"Building time     : {(endbuild - startbuild):0.2f} s")
 print(f"Simulation time   : {(endsimulate - endbuild):0.2f} s")
 print(f"Time step         : {(defaultclock.dt * 1000.0):0.2f} ms")
+
+device.delete(force=True)

--- a/brian2_benchmark/complicated_small_omp.py
+++ b/brian2_benchmark/complicated_small_omp.py
@@ -3,7 +3,8 @@ Multithread tests in OpenMP standalone mode test for complicated small model.
 """
 
 import time
-import os, sys
+import os
+import sys
 import numpy as np
 from brian2 import (
     ufarad,

--- a/brian2_benchmark/complicated_small_omp.py
+++ b/brian2_benchmark/complicated_small_omp.py
@@ -3,7 +3,7 @@ Multithread tests in OpenMP standalone mode test for complicated small model.
 """
 
 import time
-import os
+import os,sys
 import numpy as np
 from brian2 import (
     ufarad,

--- a/brian2_benchmark/complicated_small_omp.py
+++ b/brian2_benchmark/complicated_small_omp.py
@@ -85,11 +85,7 @@ beta_n = .5*exp((10*mV-v+VT)/(40*mV))/ms : Hz
 )
 defaultclock.dt = 0.05 * ms
 P = NeuronGroup(
-    400,
-    model=eqs,
-    threshold="v>25*mV",
-    refractory='v>-25*mV',
-    method="rk4"
+    400, model=eqs, threshold="v>25*mV", refractory="v>-25*mV", method="rk4"
 )
 
 Ci = Synapses(

--- a/brian2_benchmark/complicated_small_omp.py
+++ b/brian2_benchmark/complicated_small_omp.py
@@ -3,7 +3,7 @@ Multithread tests in OpenMP standalone mode test for complicated small model.
 """
 
 import time
-import os,sys
+import os, sys
 import numpy as np
 from brian2 import (
     ufarad,

--- a/brian2_benchmark/simple_large.py
+++ b/brian2_benchmark/simple_large.py
@@ -14,6 +14,7 @@ from brian2 import (
     SpikeMonitor,
     Synapses,
     codegen,
+    device,
 )
 
 codegen.target = "cython"
@@ -84,3 +85,5 @@ endsimulate = time.time()
 print(f"Building time     : {(endbuild - startbuild):0.2f} s")
 print(f"Simulation time   : {(endsimulate - endbuild):0.2f} s")
 print(f"Time step         : {(defaultclock.dt * 1000.0):0.2f} ms")
+
+device.delete(force=True)

--- a/brian2_benchmark/simple_large_omp.py
+++ b/brian2_benchmark/simple_large_omp.py
@@ -3,7 +3,8 @@ Multithread tests in OpenMP standalone mode test for simple large model.
 """
 
 import time
-import os, sys
+import os
+import sys
 import numpy as np
 
 from brian2 import (

--- a/brian2_benchmark/simple_large_omp.py
+++ b/brian2_benchmark/simple_large_omp.py
@@ -3,7 +3,7 @@ Multithread tests in OpenMP standalone mode test for simple large model.
 """
 
 import time
-import os
+import os, sys
 import numpy as np
 
 from brian2 import (
@@ -17,9 +17,10 @@ from brian2 import (
     SpikeGeneratorGroup,
     SpikeMonitor,
     Synapses,
+    device,
 )
 
-set_device("cpp_standalone", directory="SimpleLarge")
+set_device("cpp_standalone", directory=sys.argv[0][:-3])
 prefs.devices.cpp_standalone.openmp_threads = os.cpu_count()
 
 startbuild = time.time()
@@ -88,3 +89,5 @@ endsimulate = time.time()
 print(f"Building time     : {(endbuild - startbuild):0.2f} s")
 print(f"Simulation time   : {(endsimulate - endbuild):0.2f} s")
 print(f"Time step         : {(defaultclock.dt * 1000.0):0.2f} ms")
+
+device.delete(force=True)

--- a/run.sh
+++ b/run.sh
@@ -23,6 +23,8 @@ do
 
   for i in {0..9}
   do
+    # removes precompiled results and caches
+    rm -fR ${benchmark_file%%.py} ~/.cython
     python3 $benchmark_file
     echo ""
   done


### PR DESCRIPTION
Updated code clears all caches every run. The `refractory` argument was added to `NeuroGroup()` to avoid a warning message.